### PR TITLE
Changed documentation route

### DIFF
--- a/src/api/v1/routes/index.js
+++ b/src/api/v1/routes/index.js
@@ -5,7 +5,7 @@ import responseHandler from "../../utils/responseHandler";
 const router = express.Router();
 
 // route for documentation in json
-router.get("/documentation", (req, res) => {
+router.get("/", (req, res) => {
   res.status(200).json(swaggerSpec);
 });
 


### PR DESCRIPTION
As per Mark’s request. The documentation endpoint is meant to be on the main URL not a ‘/docs’ or ‘/documentation’ in this case